### PR TITLE
Ajouté cancel item si joueur visé tuto

### DIFF
--- a/roleplay_dealer.sp
+++ b/roleplay_dealer.sp
@@ -57,6 +57,7 @@ public Action Cmd_ItemDrugs(int args) {
 		}
 		if( !rp_IsTutorialOver(target) ) {
 			CPrintToChat(target, "{lightblue}[TSX-RP]{default} %N n'a pas terminé le tutorial.", target);
+			ITEM_CANCEL(client, item_id);
 			return Plugin_Handled;
 		}
 		


### PR DESCRIPTION
PCP2 ne remboursait pas quand on utilisait l'item sur un tuto
