### PR TITLE
verification zone target /jail tribu

### DIFF
--- a/jobs/roleplay_police.sp
+++ b/jobs/roleplay_police.sp
@@ -755,7 +755,9 @@ public Action Cmd_Jail(int client) {
 		ACCESS_DENIED(client);
 	}
 	
-	if( rp_GetZoneInt(Czone, zone_type_type) == 101 && (job == 101 || job == 102 || job == 103 || job == 104 || job == 105 || job == 106) ) {
+	if( (rp_GetZoneInt(Czone, zone_type_type) == 101) // On check si le CT est bien dans le tribunal
+			&& (rp_GetZoneInt(Tzone, zone_type_type) == 101) // On check si la cible est bien dans le tribunal (ticket #1029)
+			&& (job == 101 || job == 102 || job == 103 || job == 104 || job == 105 || job == 106) ) {
 
 		if(job == 106 && GetClientTeam(target) == CS_TEAM_CT ){
 			ACCESS_DENIED(client);


### PR DESCRIPTION
Un CT tribu pouvait /jail depuis le tribu vers en dehors du tribu. Me
semble que ca avait été laissé exprès pour pouvoir jail les nuisances
sonores devant la porte. Si c'est le cas, annule la request, si non,
j'ai rajouté la condition et tu peux merge
