### PR TITLE
correction log alcool

### DIFF
--- a/jobs/roleplay_police.sp
+++ b/jobs/roleplay_police.sp
@@ -756,8 +756,11 @@ public Action Cmd_Jail(int client) {
 	}
 	
 	if( (rp_GetZoneInt(Czone, zone_type_type) == 101) // On check si le CT est bien dans le tribunal
-			&& (rp_GetZoneInt(Tzone, zone_type_type) == 101) // On check si la cible est bien dans le tribunal (ticket #1029)
 			&& (job == 101 || job == 102 || job == 103 || job == 104 || job == 105 || job == 106) ) {
+
+		if (rp_GetZoneInt(Tzone, zone_type_type) != 101){ // On check si la cible est bien dans le tribunal (ticket #1029)
+			ACCESS_DENIED(client);
+		}
 
 		if(job == 106 && GetClientTeam(target) == CS_TEAM_CT ){
 			ACCESS_DENIED(client);

--- a/jobs/roleplay_sexshop.sp
+++ b/jobs/roleplay_sexshop.sp
@@ -366,7 +366,7 @@ public Action Cmd_ItemAlcool(int args) {
 		GetClientAbsOrigin(client, vecTarget);
 		TE_SetupBeamRingPoint(vecTarget, 10.0, 500.0, g_cBeam, g_cGlow, 0, 15, 0.5, 50.0, 0.0, { 255, 0, 191, 200}, 10, 0);
 		rp_SetClientInt(client, i_LastAgression, GetTime());
-		LogToGame("[TSX-RP] [DROGUE] %L a alcoolisé %l.", client, target);
+		LogToGame("[TSX-RP] [DROGUE] %L a alcoolisé %L.", client, target);
 	}
 
 	float level = rp_GetClientFloat(target, fl_Alcool) + GetCmdArgFloat(2);


### PR DESCRIPTION
Une petite erreur s'était glissé dans les logs
LogToGame("[TSX-RP] [DROGUE] %L a alcoolisé %l.", client, target);
donnait
L 01/05/2016 - 23:10:28: [TSX-RP] [DROGUE]
ClemSpark<332><STEAM_1:0:47117315><> a alcoolisé l.
