### PR TITLE
Modif quête coup de main pour la justice

### DIFF
--- a/quests/jobs/rp_quest_mercenaire-002.sp
+++ b/quests/jobs/rp_quest_mercenaire-002.sp
@@ -114,7 +114,10 @@ public Action timerStartQuest(Handle timer, any client) {
 		rp_QuestStepFail(client, g_ObjectiveID);
 }
 public Action fwdTueurDead(int client, int attacker, float& respawn) {
-	rp_QuestStepFail(client, g_ObjectiveID);
+    int target = rp_GetClientInt(client, i_ToKill);
+    if( target > 0  && attacker == target) {
+        rp_QuestStepFail(client, g_ObjectiveID);
+    }
 }
 public Action fwdTueurKill(int client, int attacker, float& respawn) {
 	


### PR DESCRIPTION
Ajout d'une fonction dans la quête, elle tombe en échec uniquement si l'attaquant meurt par sa cible